### PR TITLE
[fix]: Make load synchronous to prevent racing condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ Optionally, you can [preload](#preload) your `.env` files instead!
 
 ## Env Configuration File
 
-The easiest and cleanest way to load `.env` files is to create an **env.config.(m)js** file located at the **project's current working root directory** that exports an object which follows the [config argument options](#config-argument-options) pattern. The environment naming is unopinionated -- they can be named anything you'd like (for example: `dev`, `staging`, `prepublish`, etc) -- however, the name must match one of environments specified in the configuration file:
+The easiest and cleanest way to load `.env` files is to create an **env.config.json** file located at the **project's current working root directory** that is an object which follows the [config argument options](#config-argument-options) pattern. The environment naming is unopinionated -- they can be named anything you'd like (for example: `dev`, `staging`, `prepublish`, etc) -- however, the name must match one of environments specified in the configuration file:
 
-**env.config.js**
-```js
-module.exports = {
+**env.config.json**
+```json
+{
   "development": {
     "debug": true,
     "paths": [".env.base", ".env.dev"],
@@ -168,26 +168,6 @@ module.exports = {
     "paths": [".env.base", ".env.dev"],
   }
 }
-```
-
-**env.config.mjs** (beta)
-```js
-const config = {
-  "development": {
-    "debug": true,
-    "paths": [".env.base", ".env.dev"],
-    "override": true
-  },
-  "production": {
-    "paths": ".env.prod",
-  },
-  "test": {
-    "dir": "custom/path/to/directory",
-    "paths": [".env.base", ".env.dev"],
-  }
-}
-
-export default config;
 ```
 
 Then in your `package.json`, add a [LOAD_CONFIG](#load_config) variable to load one of the configurations by an environment name:
@@ -218,7 +198,7 @@ Then, either [preload](#preload) or import the `snackables` package as early as 
 
 #### LOAD_CONFIG
 
-By defining a `LOAD_CONFIG` variable, this will let snackables know you'ld like to load an **env.config.(m)js** file according to a defined environment name. The environment naming is unopinionated -- they can be named anything you'd like (for example: `dev`, `staging`, `prepublish`, etc) -- however, the name must match one of environments specified in the configuration file.
+By defining a `LOAD_CONFIG` variable, this will let snackables know you'ld like to load an **env.config.json** file according to a defined environment name. The environment naming is unopinionated -- they can be named anything you'd like (for example: `dev`, `staging`, `prepublish`, etc) -- however, the name must match one of environments specified in the configuration file.
 
 ```json
 {
@@ -231,9 +211,9 @@ By defining a `LOAD_CONFIG` variable, this will let snackables know you'ld like 
 }
 ```
 
-**env.config.js**
-```js
-module.exports = {
+**env.config.json**
+```json
+{
   "development": {
     "debug": true,
     "paths": [".env.base", ".env.dev"],
@@ -247,26 +227,6 @@ module.exports = {
     "paths": [".env.base", ".env.dev"],
   }
 }
-```
-
-**env.config.mjs** (beta)
-```js
-const config = {
-  "development": {
-    "debug": true,
-    "paths": [".env.base", ".env.dev"],
-    "override": true
-  },
-  "production": {
-    "paths": ".env.prod",
-  },
-  "test": {
-    "dir": "custom/path/to/directory",
-    "paths": [".env.base", ".env.dev"],
-  }
-}
-
-export default config;
 ```
 
 ⚠️ The Env variables listed below will take precendence over `LOAD_CONFIG`. For example, if you mistakely use `LOAD_CONFIG` with `ENV_LOAD`, then `ENV_LOAD` will take precendence.
@@ -594,7 +554,7 @@ line'}
 
 ## Load Method
 
-If you wish to manually load the **env.config.(m)js** file, then you can utilize the `load` method. Please note that this only **asynchronously** loads the configuration file and will not automatically assign Envs; instead, you'll have to manually pass its arguments to the [config method](#config-method).
+If you wish to manually load the **env.config.json** file, then you can utilize the `load` method. Please note that this **synchronously** loads the configuration file and will not automatically assign Envs; instead, you'll have to manually pass its arguments to the [config method](#config-method).
 
 ### Load Argument Options
 
@@ -606,46 +566,28 @@ dir: string | undefined
 
 #### Load env
 
-For some use cases, you may want to manually load the **env.config.(m)js** file and pass its arguments to the [config method](#config-method). To do so, pass `load` an environment name as the first argument:
+For some use cases, you may want to manually load the **env.config.json** file and pass its arguments to the [config method](#config-method). To do so, pass `load` an environment name as the first argument:
 
 ```js
 const { config, load } = require("snackables");
 // import { config, load } from "snackables";
 
-// CommonJS
-(async () => {
-  const configArgs = await load("development"); // will return an object of config arguments
-  console.log(typeof configArgs, configArgs) // object { paths: ".env.dev", debug: true }
-
-  config(configArgs) // parses .env.dev and assigns it to process.env
-})();
-
-// ESM (top-level await)
-const esmConfigArgs = await load("development"); // will return an object of config arguments
-console.log(typeof esmConfigArgs, esmConfigArgs) // object { paths: ".env.dev", debug: true }
-config(esmConfigArgs) // parses .env.dev and assigns it to process.env
+const configArgs = load("development"); // will return an object of config arguments
+console.log(typeof configArgs, configArgs) // object { paths: ".env.dev", debug: true }
+config(configArgs) // parses .env.dev and assigns it to process.env
 ```
 
 #### Load dir
 
-For some use cases, you may want to manually load an **env.config.(m)js** file **not** located at the project's root directory and pass its arguments to the [config method](#config-method). To do so, pass `load` an environment name as the first argument and a directory name as a second argument:
+For some use cases, you may want to manually load an **env.config.json** file **not** located at the project's root directory and pass its arguments to the [config method](#config-method). To do so, pass `load` an environment name as the first argument and a directory name as a second argument:
 
 ```js
 const { config, load } = require("snackables");
 // import { config, load } from "snackables";
 
-// CommonJS
-(async () => {
-  const configArgs = await load("development", "path/to/custom/directory"); // will return an object of config arguments
-  console.log(typeof configArgs, configArgs) // object { paths: ".env.dev", debug: true }
-
-  config(configArgs) // parses .env.dev and assigns it to process.env
-})();
-
-// ESM (top-level await)
-const esmConfigArgs = await load("development", "path/to/custom/directory"); // will return an object of config arguments
-console.log(typeof esmConfigArgs, esmConfigArgs) // object { paths: ".env.dev", debug: true }
-config(esmConfigArgs) // parses .env.dev and assigns it to process.env
+const configArgs = load("development", "path/to/custom/directory"); // will return an object of config arguments
+console.log(typeof configArgs, configArgs) // object { paths: ".env.dev", debug: true }
+config(configArgs) // parses .env.dev and assigns it to process.env
 ```
 
 ## Interpolation

--- a/UPDATESLOG.md
+++ b/UPDATESLOG.md
@@ -2,6 +2,13 @@
 
 All notable updates to this project will be documented in this file. See [SemVer 2.0](https://semver.org/) for commit guidelines.
 
+## [3.0.3] - 2021-29-05
+
+### Changed
+
+- Make `load` synchronous due to `import`/`require` racing condition
+- Remove support for importing a `.(m)js` config
+
 ## [3.0.2] - 2021-29-05
 
 ### Changed

--- a/__tests__/invalidconfig.spec.ts
+++ b/__tests__/invalidconfig.spec.ts
@@ -15,7 +15,7 @@ describe("Invalid Config", () => {
 
     await waitFor(() => {
       expect(logWarning).toHaveBeenCalledWith(
-        "Unable to locate a 'development' configuration within 'env.config.(m)js'!"
+        "Unable to locate a 'development' configuration within 'env.config.json'!"
       );
     });
   });

--- a/__tests__/load.spec.ts
+++ b/__tests__/load.spec.ts
@@ -13,23 +13,23 @@ describe("Load Method", () => {
   });
 
   it("fails to load a config file from an invalid directory", async () => {
-    await load("dev", "invalid");
+    load("dev", "invalid");
 
     expect(logWarning).toHaveBeenCalledWith(
-      "Unable to locate an 'env.config.(m)js' file in the specified directory!"
+      "Unable to locate an 'env.config.json' file in the specified directory!"
     );
   });
 
   it("fails to load a config file from an 'LOAD_ENV' environment", async () => {
-    await load("dev", "tests");
+    load("dev", "tests");
 
     expect(logWarning).toHaveBeenCalledWith(
-      "Unable to locate a 'dev' configuration within 'env.config.(m)js'!"
+      "Unable to locate a 'dev' configuration within 'env.config.json'!"
     );
   });
 
   it("loads a config file and returns an config arguments", async () => {
-    const config = await load("test");
+    const config = load("test");
 
     expect(config).toEqual({
       debug: true,

--- a/__tests__/loadconfig.spec.ts
+++ b/__tests__/loadconfig.spec.ts
@@ -1,5 +1,4 @@
 import { logMessage } from "../log";
-import waitFor from "../utils/waitFor";
 
 jest.mock("../log", () => ({
   __esModule: true,
@@ -7,15 +6,12 @@ jest.mock("../log", () => ({
   logWarning: jest.fn()
 }));
 
-it("loads and parses an 'env.config.js' file and registers ENVs when the package is imported", async () => {
+it("loads and parses an 'env.config.json' file and registers ENVs when the package is imported", async () => {
   expect(process.env.BASE).toBeUndefined();
   process.env.LOAD_CONFIG = "test";
 
-  import("../index");
+  require("../index");
 
-  await waitFor(() => {
-    expect(logMessage).toHaveBeenCalledWith(`Loaded env from tests/.env.base`);
-
-    expect(process.env.BASE).toEqual("hello");
-  });
+  expect(logMessage).toHaveBeenCalledWith(`Loaded env from tests/.env.base`);
+  expect(process.env.BASE).toEqual("hello");
 });

--- a/__tests__/preload.spec.ts
+++ b/__tests__/preload.spec.ts
@@ -1,5 +1,4 @@
 import { logMessage } from "../log";
-import waitFor from "../utils/waitFor";
 
 jest.mock("../log", () => ({
   __esModule: true,
@@ -14,19 +13,15 @@ it("parses and assigns Envs within ENV_LOAD once the package is either imported 
   process.env.ENV_LOAD = ".env.preload,.env.example";
   process.env.ENV_DEBUG = "true";
 
-  import("../index");
+  require("../index");
 
-  await waitFor(() => {
-    expect(logMessage).toHaveBeenCalledWith(
-      `Loaded env from ${process.env.ENV_DIR}/.env.preload`
-    );
-  });
+  expect(logMessage).toHaveBeenCalledWith(
+    `Loaded env from ${process.env.ENV_DIR}/.env.preload`
+  );
 
-  await waitFor(() => {
-    expect(logMessage).toHaveBeenCalledWith(
-      `Loaded env from ${process.env.ENV_DIR}/.env.example`
-    );
-  });
+  expect(logMessage).toHaveBeenCalledWith(
+    `Loaded env from ${process.env.ENV_DIR}/.env.example`
+  );
 
   expect(process.env.PRELOAD).toEqual("true");
   expect(process.env.EXAMPLE).toEqual("hello");

--- a/env.config.js
+++ b/env.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  test: {
-    dir: "tests",
-    debug: true,
-    paths: ".env.base",
-  }
-};

--- a/env.config.json
+++ b/env.config.json
@@ -1,0 +1,7 @@
+{
+  "test": {
+    "dir": "tests",
+    "debug": true,
+    "paths": ".env.base"
+  }
+}

--- a/importFile/index.ts
+++ b/importFile/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 /**
  * A utility function that attempts to `import`/`require` a JavaScript `env.config.(m)js` file.
  *

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import type { ConfigOptions } from "./types/index";
 /**
  * Immediately loads a single or multiple `.env` file contents into {@link https://nodejs.org/api/process.html#process_process_env | `process.env`} when the package is preloaded or imported.
  */
-(async function (): Promise<void> {
+(function (): void {
   const { env } = process;
   const { LOAD_CONFIG } = env;
 
@@ -19,7 +19,7 @@ import type { ConfigOptions } from "./types/index";
 
   // checks if LOAD_CONFIG is defined and assigns config options
   if (LOAD_CONFIG) {
-    const envConfig = await load(LOAD_CONFIG);
+    const envConfig = load(LOAD_CONFIG);
 
     if (Object.keys(envConfig).length) {
       dir = envConfig.dir;

--- a/load/index.ts
+++ b/load/index.ts
@@ -1,41 +1,49 @@
+import { readFileSync } from "fs";
 import { logWarning } from "../log";
 import getFilePath from "../getFilePath";
 import fileExists from "../fileExists";
-import importFile from "../importFile";
+// import importFile from "../importFile";
 import type { ConfigOptions } from "../types/index";
 
 /**
- * Loads a configuration object from the `env.config.(m)js` file based upon `LOAD_ENV`.
+ * Loads a configuration object from the `env.config.json` file based upon `LOAD_ENV`.
  *
  * @param env - the environment to be loaded
  * @param dir - the directory where the config is located
- * @returns a promise that resolves a config file as { key: value } pairs to be used with the `config` function
+ * @returns a config file as { key: value } pairs to be used with the `config` function
  * @example load("development")
  */
-export default async function load(
-  env: string,
-  dir?: string
-): Promise<ConfigOptions> {
+export default function load(env: string, dir?: string): ConfigOptions {
   try {
-    const configName = "env.config";
-    let configPath = getFilePath(`${configName}.js`, dir);
+    const configName = "env.config.json";
+    const configPath = getFilePath(configName, dir);
+    // let configPath = getFilePath(`${configName}.js`, dir);
 
-    if (!fileExists(configPath)) {
-      configPath = getFilePath(`${configName}.mjs`, dir);
-      if (!fileExists(configPath))
-        throw String(
-          `Unable to locate an '${configName}.(m)js' file in the specified directory!`
-        );
-    }
+    if (!fileExists(configPath))
+      throw String(
+        `Unable to locate an '${configName}' file in the specified directory!`
+      );
 
-    const config = await importFile(configPath);
+    // if (!fileExists(configPath)) {
+    //   configPath = getFilePath(`${configName}.mjs`, dir);
+    //   if (!fileExists(configPath))
+    //     throw String(
+    //       `Unable to locate an '${configName}.(m)js' file in the specified directory!`
+    //     );
+    // }
+
+    // TODO - Change this use `importFile`, however this may cause a racing condition.
+    // const config = await importFile(configPath);
+    const file = readFileSync(configPath, { encoding: "utf-8" });
+
+    const config = JSON.parse(file);
 
     if (
       typeof config !== "object" ||
       !Object.prototype.hasOwnProperty.call(config, env)
     )
       throw String(
-        `Unable to locate a '${env}' configuration within '${configName}.(m)js'!`
+        `Unable to locate a '${env}' configuration within '${configName}'!`
       );
 
     return config[env] as ConfigOptions;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snackables",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Loading byte sized ENVs made simple.",
   "main": "index.js",
   "module": "esm/index.js",

--- a/tests/env.config.json
+++ b/tests/env.config.json
@@ -1,0 +1,7 @@
+{
+  "test": {
+    "dir": "tests",
+    "debug": true,
+    "paths": ".env.base"
+  }
+}

--- a/tests/env.config.mjs
+++ b/tests/env.config.mjs
@@ -1,7 +1,0 @@
-module.exports = {
-  test: {
-    dir: "tests",
-    debug: true,
-    paths: ".env.base"
-  }
-};

--- a/types/default.test-d.ts
+++ b/types/default.test-d.ts
@@ -17,8 +17,8 @@ expectType<string>(parsed["BASE"]);
 expectType<ParsedEnvs>(extracted);
 expectType<string>(extracted["BASE"]);
 
-expectType<Promise<ConfigOptions>>(snackables.load("test"));
-const envConfig = await snackables.load("test");
+expectType<ConfigOptions>(snackables.load("test"));
+const envConfig = snackables.load("test");
 expectType<ConfigOptions>(envConfig);
 expectType<string>(envConfig["dir"] as string);
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,14 +42,14 @@ export interface ConfigOutput {
 export declare function config(options?: ConfigOptions): ConfigOutput;
 
 /**
- * Loads a configuration object from the `env.config.(m)js` file based upon `LOAD_ENV`.
+ * Loads a configuration object from the `env.config.json` file based upon `LOAD_ENV`.
  *
  * @param env - the environment to be loaded
  * @param dir - the directory where the config is located
- * @returns a promise that resolves a config file as { key: value } pairs to be used with the `config` function
+ * @returns a config file as { key: value } pairs to be used with the `config` function
  * @example load("development")
  */
- export declare function load(env: string, dir?: string): Promise<ConfigOptions>;
+ export declare function load(env: string, dir?: string): ConfigOptions;
 
 /**
  * Parses a string or buffer of Envs into an object.

--- a/types/named.test-d.ts
+++ b/types/named.test-d.ts
@@ -17,8 +17,8 @@ expectType<string>(parsed["BASE"]);
 expectType<ParsedEnvs>(extracted);
 expectType<string>(extracted["BASE"]);
 
-expectType<Promise<ConfigOptions>>(load("test"));
-const envConfig = await load("test");
+expectType<ConfigOptions>(load("test"));
+const envConfig = load("test");
 expectType<ConfigOptions>(envConfig);
 expectType<string>(envConfig["dir"] as string);
 


### PR DESCRIPTION
- Make `load` synchronous due to `import`/`require` racing condition
- Remove support for importing a `.(m)js` config